### PR TITLE
preserve direction in adjacency matrices

### DIFF
--- a/digraph.cabal
+++ b/digraph.cabal
@@ -1,67 +1,64 @@
-cabal-version: 2.4
-name: digraph
-version: 0.2.2
-synopsis: Directed Graphs
-description: Directed graphs implementation that is based on unordered-containers
-homepage: https://github.com/kadena-io/digraph
-bug-reports: https://github.com/kadena-io/digraph/issues
-license: BSD-3-Clause
-license-file: LICENSE
-author: Lars Kuhtz
-maintainer: lars@kadena.io
-copyright: Copyright (c) 2019 - 2021, Kadena LLC
-category: Data, Mathematics
-tested-with:
-    GHC==9.0.1
-    GHC==8.10.5
-    GHC==8.8.4
+cabal-version:      2.4
+name:               digraph
+version:            0.2.2
+synopsis:           Directed Graphs
+description:
+  Directed graphs implementation that is based on unordered-containers
+
+homepage:           https://github.com/kadena-io/digraph
+bug-reports:        https://github.com/kadena-io/digraph/issues
+license:            BSD-3-Clause
+license-file:       LICENSE
+author:             Lars Kuhtz
+maintainer:         lars@kadena.io
+copyright:          Copyright (c) 2019 - 2021, Kadena LLC
+category:           Data, Mathematics
+tested-with:        GHC ==8.8.4 || ==8.10.5 || ==9.0.1
 extra-source-files:
-    README.md
-    CHANGELOG.md
+  CHANGELOG.md
+  README.md
 
 source-repository head
-    type: git
-    location: https://github.com/kadena-io/digraph.git
+  type:     git
+  location: https://github.com/kadena-io/digraph.git
 
 library
-    hs-source-dirs: src
-    default-language: Haskell2010
-    ghc-options:
-        -Wall
-    exposed-modules:
-        Data.DiGraph
-        Data.DiGraph.FloydWarshall
-        Data.DiGraph.Random
-    build-depends:
-        , base >=4.10 && <4.16
-        , containers >=0.5
-        , deepseq >=1.4
-        , hashable >=1.2
-        , massiv >=0.3
-        , mwc-random >=0.14
-        , streaming >=0.2
-        , transformers >=0.5
-        , unordered-containers >=0.2
+  hs-source-dirs:   src
+  default-language: Haskell2010
+  ghc-options:      -Wall
+  exposed-modules:
+    Data.DiGraph
+    Data.DiGraph.FloydWarshall
+    Data.DiGraph.Random
+
+  build-depends:
+    , base                  >=4.10 && <=4.16.0.0
+    , containers            >=0.5
+    , deepseq               >=1.4
+    , hashable              >=1.2
+    , massiv                >=0.3
+    , mwc-random            >=0.14
+    , streaming             >=0.2
+    , transformers          >=0.5
+    , unordered-containers  >=0.2
 
 test-suite digraph-tests
-    type: exitcode-stdio-1.0
-    hs-source-dirs: test
-    default-language: Haskell2010
-    main-is: Main.hs
-    ghc-options:
-        -Wall
-        -threaded
-        -with-rtsopts=-N
-    other-modules:
-        Data.DiGraph.Test
-        Data.DiGraph.Random.Test
-    build-depends:
-        -- internal
-        , digraph
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  default-language: Haskell2010
+  main-is:          Main.hs
+  ghc-options:      -Wall -threaded -with-rtsopts=-N
+  other-modules:
+    Data.DiGraph.Random.Test
+    Data.DiGraph.Test
 
-        -- external
-        , QuickCheck >=2.11
-        , base >=4.10 && <4.16
-        , fgl >=5.7
-        , hashable >=1.2
-        , massiv >=0.3
+  build-depends:
+    , base        >=4.10 && <=4.16.0.0
+    , digraph
+    , fgl         >=5.7
+    , hashable    >=1.2
+    , massiv      >=0.3
+    , QuickCheck  >=2.11
+
+-- internal
+-- external

--- a/digraph.cabal
+++ b/digraph.cabal
@@ -32,7 +32,7 @@ library
     Data.DiGraph.Random
 
   build-depends:
-    , base                  >=4.10 && <=4.16.0.0
+    , base                  >=4.10 && <4.17
     , containers            >=0.5
     , deepseq               >=1.4
     , hashable              >=1.2

--- a/src/Data/DiGraph/FloydWarshall.hs
+++ b/src/Data/DiGraph/FloydWarshall.hs
@@ -69,7 +69,7 @@ type AdjacencySets = HM.HashMap Int (HS.HashSet Int)
 --
 -- (uses massiv)
 
--- | Assumes that the input is an undirected graph and that the vertex
+-- | Assumes that the input is an directed graph and that the vertex
 -- set is a prefix of the natural numbers.
 --
 fromAdjacencySets :: AdjacencySets -> DenseAdjMatrix
@@ -78,7 +78,6 @@ fromAdjacencySets g = makeArray Seq (Sz (n :. n)) go
     n = HM.size g
     go (i :. j)
         | isEdge (i, j) = 1
-        | isEdge (j, i) = 1
         | otherwise = 0
     isEdge (a, b) = maybe False (HS.member b) $ HM.lookup a g
 


### PR DESCRIPTION
I think it would be better to preserve direction of edges when creating the adjacency matrix.