### PR TITLE
Preserve direction in adjacency matrices

### DIFF
--- a/src/Data/DiGraph.hs
+++ b/src/Data/DiGraph.hs
@@ -82,6 +82,8 @@ module Data.DiGraph
 , petersonGraph
 , twentyChainGraph
 , hoffmanSingleton
+, pentagon
+, ascendingCube
 
 ) where
 
@@ -612,3 +614,16 @@ hoffmanSingleton = pentagons `union` pentagrams `union` connections
         , i <- [0 .. 4]
         , let b = q_off i ((h * i + j) `mod` 5)
         ]
+
+pentagon :: DiGraph Int
+pentagon = fromEdges $ HS.fromList [(i,(i+1) `mod` 5) | i <- [0..4] ]
+
+ascendingCube :: DiGraph (Int,Int,Int)
+ascendingCube = fromEdges $ HS.fromList $ mconcat
+  [ [ ((0,a,b),(1,a,b))
+    , ((a,0,b),(a,1,b))
+    , ((a,b,0),(a,b,1))
+    ]
+  | a <- [0,1]
+  , b <- [0,1]
+  ]

--- a/src/Data/DiGraph/FloydWarshall.hs
+++ b/src/Data/DiGraph/FloydWarshall.hs
@@ -69,7 +69,7 @@ type AdjacencySets = HM.HashMap Int (HS.HashSet Int)
 --
 -- (uses massiv)
 
--- | Assumes that the input is an undirected graph and that the vertex
+-- | Assumes that the input is an directed graph and that the vertex
 -- set is a prefix of the natural numbers.
 --
 fromAdjacencySets :: AdjacencySets -> DenseAdjMatrix
@@ -78,7 +78,6 @@ fromAdjacencySets g = makeArray Seq (Sz (n :. n)) go
     n = HM.size g
     go (i :. j)
         | isEdge (i, j) = 1
-        | isEdge (j, i) = 1
         | otherwise = 0
     isEdge (a, b) = maybe False (HS.member b) $ HM.lookup a g
 

--- a/test/Data/DiGraph/Test.hs
+++ b/test/Data/DiGraph/Test.hs
@@ -43,6 +43,9 @@ properties_undirected g =
     , ("isSymmetric", property $ isSymmetric g)
     ]
 
+properties_directed :: Eq a => Hashable a => DiGraph a -> [(String, Property)]
+properties_directed = filter ((/=) "isSymmetric" . fst) . properties_undirected
+
 properties_emptyGraph :: Natural -> [(String, Property)]
 properties_emptyGraph n = prefixProperties ("emptyGraph of order " <> show n <> ": ")
     $ ("order == " <> show n, order g === n)
@@ -95,6 +98,28 @@ properties_hoffmanSingletonGraph = prefixProperties "HoffmanSingletonGraph: "
   where
     g = hoffmanSingleton
 
+properties_pentagon :: [(String,Property)]
+properties_pentagon = prefixProperties "Pentagon: "
+    $ ("order == 5",order g === 5)
+    : ("size == 5",symSize g === 5)
+    : ("outDegree == 1",maxOutDegree g === 1)
+    : ("isRegular", property $ isRegular g)
+    : ("diameter == 4", diameter g === Just 4)
+    : properties_directed g
+  where
+    g = pentagon
+
+properties_ascendingCube :: [(String,Property)]
+properties_ascendingCube = prefixProperties "Ascending Cube: "
+    $ ("order == 8",order g === 8)
+    : ("size == 12",symSize g === 12)
+    : ("outDegree == 3",maxOutDegree g === 3)
+    : ("isIrRegular", property $ not $ isRegular g)
+    : ("diameter == Nothing", diameter g === Nothing)
+    : properties_directed g
+  where
+    g = ascendingCube
+
 -- | Test Properties.
 --
 properties :: [(String, Property)]
@@ -105,4 +130,6 @@ properties = (concat :: [[(String, Property)]] -> [(String, Property)])
     , properties_petersonGraph
     , properties_twentyChainGraph
     , properties_hoffmanSingletonGraph
+    , properties_pentagon
+    , properties_ascendingCube
     ]


### PR DESCRIPTION
Closes #8 
Replacing #7 because the source branch needed to change.